### PR TITLE
springtainer-mongodb: Update auf Spring Boot 4.1.X und Java 25

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
     branches:
       # Runs only on push to the master branch
       - master
+      - spring-boot-4-migration
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,6 @@ on:
     branches:
       # Runs only on push to the master branch
       - master
-      - spring-boot-4-migration
 
 jobs:
   release:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 <dependency>
   <groupId>com.avides.springboot.springtainer</groupId>
   <artifactId>springtainer-mongodb</artifactId>
-  <version>2.0.0</version>
+  <version>3.0.0-RC1</version>
   <scope>test</scope>
 </dependency>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <maven-failsafe-plugin.version>3.5.6</maven-failsafe-plugin.version>
     <maven-enforcer-plugin.version>3.6.3</maven-enforcer-plugin.version>
     <maven-release-plugin.version>3.3.1</maven-release-plugin.version>
-    <maven-scm-provider-gitexe.version>1.11.3</maven-scm-provider-gitexe.version>
+    <maven-scm-provider-gitexe.version>2.2.1</maven-scm-provider-gitexe.version>
     <exists-maven-plugin.version>0.15.2</exists-maven-plugin.version>
     <central-publishing-maven-plugin.version>0.11.0</central-publishing-maven-plugin.version>
     <!-- Common -->

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>com.avides.springboot.springtainer</groupId>
   <artifactId>springtainer-mongodb</artifactId>
-  <version>2.0.0</version>
+  <version>3.0.0-RC1</version>
 
   <name>springtainer-mongodb</name>
   <description>MongoDB test-container</description>
@@ -40,7 +40,7 @@
     <!-- Build -->
     <maven.build.timestamp.format>dd.MM.yyyy HH:mm</maven.build.timestamp.format>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <java.version>21</java.version>
+    <java.version>25</java.version>
     <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
     <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
     <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
@@ -53,8 +53,8 @@
     <exists-maven-plugin.version>0.15.2</exists-maven-plugin.version>
     <central-publishing-maven-plugin.version>0.11.0</central-publishing-maven-plugin.version>
     <!-- Common -->
-    <spring-boot.version>3.5.16</spring-boot.version>
-    <springtainer-common.version>2.0.0</springtainer-common.version>
+    <spring-boot.version>4.1.0</spring-boot.version>
+    <springtainer-common.version>3.0.0-RC1</springtainer-common.version>
     <lombok.version>1.18.46</lombok.version>
     <!-- Other -->
     <!-- Testing -->
@@ -140,6 +140,13 @@
       <artifactId>spring-boot-test</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- Carries MongoDataAutoConfiguration, which the integration tests rely on for the MongoTemplate against the
+         started container. -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-data-mongodb</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
@@ -162,6 +169,7 @@
         <configuration>
           <release>${java.version}</release>
           <parameters>true</parameters>
+          <proc>full</proc>
         </configuration>
       </plugin>
       <plugin>

--- a/src/main/java/com/avides/springboot/springtainer/mongodb/EmbeddedMongodbContainerAutoConfiguration.java
+++ b/src/main/java/com/avides/springboot/springtainer/mongodb/EmbeddedMongodbContainerAutoConfiguration.java
@@ -4,6 +4,7 @@ import static com.avides.springboot.springtainer.mongodb.MongodbProperties.BEAN_
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.springframework.boot.autoconfigure.AutoConfigureOrder;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -16,6 +17,10 @@ import org.springframework.core.env.ConfigurableEnvironment;
 
 import com.avides.springboot.springtainer.common.container.AbstractBuildingEmbeddedContainer;
 import com.avides.springboot.springtainer.common.container.EmbeddedContainer;
+import org.bson.Document;
+
+import com.mongodb.ConnectionString;
+import com.mongodb.MongoClientSettings;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 
@@ -48,12 +53,22 @@ public class EmbeddedMongodbContainerAutoConfiguration
             return provided;
         }
 
+        /**
+         * Sends a ping, because everything up to and including {@code getDatabase} is resolved client-side and would report a container ready that never
+         * came up. The server selection timeout is kept well below the startup timeout so a failed attempt leaves room to retry.
+         */
         @Override
         protected boolean isContainerReady(MongodbProperties properties)
         {
-            try (MongoClient mongoClient = MongoClients.create("mongodb://" + getContainerHost() + ":" + getContainerPort(properties.getPort())))
+            MongoClientSettings settings = MongoClientSettings.builder()
+                    .applyConnectionString(new ConnectionString("mongodb://" + getContainerHost() + ":" + getContainerPort(properties.getPort())))
+                    .applyToClusterSettings(builder -> builder.serverSelectionTimeout(2, TimeUnit.SECONDS))
+                    .build();
+
+            try (MongoClient mongoClient = MongoClients.create(settings))
             {
-                return mongoClient.getDatabase("admin") != null;
+                mongoClient.getDatabase("admin").runCommand(new Document("ping", Integer.valueOf(1)));
+                return true;
             }
         }
     }

--- a/src/main/java/com/avides/springboot/springtainer/mongodb/MongodbProperties.java
+++ b/src/main/java/com/avides/springboot/springtainer/mongodb/MongodbProperties.java
@@ -20,6 +20,6 @@ public class MongodbProperties extends AbstractEmbeddedContainerProperties
 
     public MongodbProperties()
     {
-        setDockerImage("mongo:4.2.24");
+        setDockerImage("mongo:8.2.12");
     }
 }

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -17,7 +17,7 @@
 			"name": "embedded.container.mongodb.docker-image",
 			"type": "java.lang.String",
 			"description": "Docker-image",
-			"defaultValue": "mongo:4.2.24"
+			"defaultValue": "mongo:8.2.12"
 		},
 		{
 			"name": "embedded.container.mongodb.port",

--- a/src/test/java/com/avides/springboot/springtainer/mongodb/AbstractIT.java
+++ b/src/test/java/com/avides/springboot/springtainer/mongodb/AbstractIT.java
@@ -12,7 +12,7 @@ import com.avides.springboot.springtainer.common.util.DockerClients;
 import com.github.dockerjava.api.DockerClient;
 
 @ExtendWith(SpringExtension.class)
-@SpringBootTest(properties = { "spring.data.mongodb.uri=mongodb://${embedded.container.mongodb.host}:${embedded.container.mongodb.port}/test" })
+@SpringBootTest(properties = { "spring.mongodb.uri=mongodb://${embedded.container.mongodb.host}:${embedded.container.mongodb.port}/test" })
 @DirtiesContext
 public abstract class AbstractIT
 {

--- a/src/test/java/com/avides/springboot/springtainer/mongodb/MongodbPropertiesTest.java
+++ b/src/test/java/com/avides/springboot/springtainer/mongodb/MongodbPropertiesTest.java
@@ -13,7 +13,7 @@ public class MongodbPropertiesTest
         var properties = new MongodbProperties();
         assertTrue(properties.isEnabled());
         assertEquals(30, properties.getStartupTimeout());
-        assertEquals("mongo:4.2.24", properties.getDockerImage());
+        assertEquals("mongo:8.2.12", properties.getDockerImage());
 
         assertEquals(27017, properties.getPort());
     }


### PR DESCRIPTION
Hebt `springtainer-mongodb` auf Spring Boot 4.1.0 und Java 25. Zielversion **3.0.0-RC1**.

- Image auf `mongo:8.2.12`.
- Der Readiness-Check lief ins Leere und prueft jetzt echt per `ping` ueber den MongoClient. Vorher endete ein nicht startender Container in einem stillen 30-Sekunden-Timeout weiter unten statt in einer `ContainerStartupFailedException`.

### Merge-Reihenfolge

Die CI dieses PRs bleibt so lange rot, bis die folgenden Libraries gemergt und released sind - ihre RC-Artefakte liegen bisher nur lokal:

- `springtainer-common`

Ticket: https://avides.atlassian.net/browse/LIBRARIES-1752
Epic: https://avides.atlassian.net/browse/ITGS-470